### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2
         with:
           java-version: 16
           distribution: 'temurin'
@@ -30,7 +30,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: Test Results Linux
           path: '**/test-results/**/*.xml'


### PR DESCRIPTION
## Summary

Pins all GitHub Actions to full commit SHAs instead of floating version tags.

**Why:** A mutable tag (e.g. `@v4`) can be force-pushed to point to different — potentially malicious — code. A full SHA is immutable and cannot be redirected.

Each pinned action retains its version tag as a comment for readability:
```yaml
uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
```

## Test plan
- [ ] Verify CI passes with pinned actions
- [ ] Confirm pinned SHAs match expected version tags