### PR TITLE
Prepare next development version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 kotlin.code.style=official
 
-jabelVersion=1.0.1-2
+jabelVersion=1.0.1-3-SNAPSHOT
 
 POM_NAME=Jabel
 POM_DESCRIPTION=Mirror of Jabel: https://github.com/bsideup/jabel


### PR DESCRIPTION
Bumps version to `1.0.1-3-SNAPSHOT` after the `1.0.1-2` release.